### PR TITLE
Fixed an error when running run.sh

### DIFF
--- a/head2toe/requirements.txt
+++ b/head2toe/requirements.txt
@@ -1,0 +1,3 @@
+absl-py==1.0.0
+numpy==1.21.5
+-e git+https://github.com/google-research/task_adaptation.git#egg=task_adaptation


### PR DESCRIPTION
```bash
./run.sh
+ pip install -r head2toe/requirements.txt
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'head2toe/requirements.txt'
```